### PR TITLE
fix greylist type enum to boolean

### DIFF
--- a/src/domainrobot.json
+++ b/src/domainrobot.json
@@ -32162,9 +32162,8 @@
           "$ref" : "#/definitions/ProtectionConstants"
         },
         "greylisting" : {
-          "type" : "string",
-          "description" : "If greylisting is activated, the first email from an unknown sender is rejected at first. Mails from this sender will only be accepted after a further delayed delivery attempt.",
-          "enum" : [ "ENABLED", "DISABLED" ]
+          "type" : "boolean",
+          "description" : "If greylisting is activated, the first email from an unknown sender is rejected at first. Mails from this sender will only be accepted after a further delayed delivery attempt."
         },
         "virus" : {
           "type" : "string",


### PR DESCRIPTION
api accepts only `true` or `false` not `ENABLED` or `DISABLED`